### PR TITLE
Rename `revision_tag` input to `service_revision_tag`

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-2
+      - uses: octue/check-semantic-version@1.0.0.beta-3
         with:
           path: pyproject.toml
+          breaking_change_indicated_by: minor

--- a/README.md
+++ b/README.md
@@ -2,34 +2,35 @@
 A GitHub action that creates a Google Pub/Sub push subscription for an Octue service.
 
 ## Usage
-To automatically create a push subscription on e.g. pull request merge / package release, add the following to your 
+To automatically create a push subscription on e.g. pull request merge / package release, add the following to your
 GitHub Actions workflow:
 
 ```yaml
 permissions:
   id-token: write
   contents: read
-  
+
 steps:
   - uses: actions/checkout@v3
-    
+
   - name: Authenticate with Google Cloud
     uses: google-github-actions/auth@v0.8.1
     with:
       create_credentials_file: true
       workload_identity_provider: 'projects/<project-id>/locations/global/workloadIdentityPools/<pool-name>/providers/<provider-name>'
       service_account: '<service-account>@<project-name>.iam.gserviceaccount.com'
-      
+
   - name: Get package version
     id: get-package-version
     run: echo "PACKAGE_VERSION=$(poetry version -s)" >> $GITHUB_OUTPUT
     # run: echo "PACKAGE_VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT  <- Use this instead if your package uses a `setup.py` file.
 
-  - uses: octue/create-push-subscription@0.1.0
+  - uses: octue/create-push-subscription@0.1.1
     with:
       project_name: <project-name>
       service_namespace: my-org
       service_name: my-service
+      service_revision_tag: ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
       push_endpoint: https://example.com/endpoint
-      revision_tag: ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
+
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -19,17 +19,17 @@ inputs:
   push_endpoint:
     description: "The HTTP/HTTPS endpoint of the service to push to. It should be fully formed and include the 'https://' prefix."
     required: true
-  revision_tag:
+  service_revision_tag:
     description: "The service revision tag (e.g. 1.0.7). If this option isn't given, a random 'cool name' tag is generated e.g. 'curious-capybara'."
     required: false
     default: ""
 
 runs:
    using: 'docker'
-   image: 'docker://octue/create-push-subscription:0.1.0'
+   image: 'docker://octue/create-push-subscription:0.1.1'
    args:
      - ${{ inputs.project_name }}
      - ${{ inputs.service_namespace }}
      - ${{ inputs.service_name }}
      - ${{ inputs.push_endpoint }}
-     - ${{ inputs.revision_tag }}
+     - ${{ inputs.service_revision_tag }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "create-push-subscription"
-version = "0.1.0"
+version = "0.1.1"
 description = "A GitHub action that creates a Google Pub/Sub push subscription for an Octue service."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#3](https://github.com/octue/create-push-subscription/pull/3))

### Enhancements
- Rename `revision_tag` input to `service_revision_tag`

### Operations
- Use latest `octue/check-semantic-version` GitHub action

<!--- END AUTOGENERATED NOTES --->